### PR TITLE
Added ubuntu15 to DIST_NAME whitelist

### DIFF
--- a/src/aerospike/scripts/aerospike-client-c.sh
+++ b/src/aerospike/scripts/aerospike-client-c.sh
@@ -66,7 +66,7 @@ detect_linux()
         return 0
         ;;
 
-      "ubuntu12" | "ubuntu13" | "ubuntu14" | "linuxmint17" )
+      "ubuntu12" | "ubuntu13" | "ubuntu14" | "ubuntu15" | "linuxmint17" )
         echo "ubuntu12"  "deb"
         return 0
         ;;


### PR DESCRIPTION
` src/aerospike/scripts/aerospike-client-c.sh` complained about ubuntu15 not being supported, so I just added it. 
The extension works as expected with php 5.6.4 on Ubuntu 15.04 (vivid).