### PR TITLE
Fix documentation for security methods and fix issue 89

### DIFF
--- a/doc/aerospike.md
+++ b/doc/aerospike.md
@@ -258,10 +258,10 @@ class Aerospike
     public int existsMany ( array $keys, array &$metadata [, array $options ] )
 
     // UDF methods
-    public int register ( string $path, string $module [, int $language = Aerospike::UDF_TYPE_LUA, [ array $options ]] )
-    public int deregister ( string $module, [ array $options ] )
-    public int listRegistered ( array &$modules [, int $language ] )
-    public int getRegistered ( string $module, string &$code )
+    public int register ( string $path, string $module [, int $language = Aerospike::UDF_TYPE_LUA [, array $options ]] )
+    public int deregister ( string $module [, array $options ] )
+    public int listRegistered ( array &$modules [, int $language [, array $options ]] )
+    public int getRegistered ( string $module, string &$code [,int $language [, array $options ]] )
     public int apply ( array $key, string $module, string $function[, array $args [, mixed &$returned [, array $options ]]] )
     public int aggregate ( string $ns, string $set, array $where, string $module, string $function, array $args, mixed &$returned [, array $options ] )
     public int scanApply ( string $ns, string $set, string $module, string $function, array $args, int &$scan_id [, array $options ] )

--- a/doc/aerospike.md
+++ b/doc/aerospike.md
@@ -294,7 +294,7 @@ class Aerospike
     public int queryRoles ( array &$roles [, array $options ] )
     public int dropRole ( string $role [, array $options ] )
     public int createUser ( string $user, string $password, array $roles [, array $options ] )
-    public int setPassword ( string $user, string $password [, array $options ] )
+    <!--public int setPassword ( string $user, string $password [, array $options ] )-->
     public int changePassword ( string $user, string $password [, array $options ] )
     public int grantRoles ( string $user, array $roles [, array $options ] )
     public int revokeRoles ( string $user, array $roles [, array $options ] )

--- a/doc/aerospike.md
+++ b/doc/aerospike.md
@@ -258,7 +258,7 @@ class Aerospike
     public int existsMany ( array $keys, array &$metadata [, array $options ] )
 
     // UDF methods
-    public int register ( string $path, string $module [, int $language = Aerospike::UDF_TYPE_LUA] )
+    public int register ( string $path, string $module [, int $language = Aerospike::UDF_TYPE_LUA, [ array $options ]] )
     public int deregister ( string $module )
     public int listRegistered ( array &$modules [, int $language ] )
     public int getRegistered ( string $module, string &$code )

--- a/doc/aerospike.md
+++ b/doc/aerospike.md
@@ -259,7 +259,7 @@ class Aerospike
 
     // UDF methods
     public int register ( string $path, string $module [, int $language = Aerospike::UDF_TYPE_LUA, [ array $options ]] )
-    public int deregister ( string $module )
+    public int deregister ( string $module, [ array $options ] )
     public int listRegistered ( array &$modules [, int $language ] )
     public int getRegistered ( string $module, string &$code )
     public int apply ( array $key, string $module, string $function[, array $args [, mixed &$returned [, array $options ]]] )

--- a/doc/aerospike_changepassword.md
+++ b/doc/aerospike_changepassword.md
@@ -44,9 +44,9 @@ if (!$client->isConnected()) {
 $res = $client->changePassword("john", "john@123");
 if ($res == Aerospike::OK) {
     echo "Password successfully changed";
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to change password";
-} elseif ($res == Aerospike::INVALID_USER) {
+} elseif ($res == Aerospike::ERR_INVALID_USER) {
     echo "User john does not exist";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_createuser.md
+++ b/doc/aerospike_createuser.md
@@ -46,9 +46,9 @@ if (!$client->isConnected()) {
 $res = $client->createUser("john", "mypass@123", array("reader"));
 if ($res == Aerospike::OK) {
     echo "User john successfully created";
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to create a new user";
-} elseif ($res == Aerospike::USER_ALREADY_EXISTS) {
+} elseif ($res == Aerospike::ERR_USER_ALREADY_EXISTS) {
     echo "User john already exists";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_dropuser.md
+++ b/doc/aerospike_dropuser.md
@@ -41,9 +41,9 @@ if (!$client->isConnected()) {
 $res = $client->dropUser("john");
 if ($res == Aerospike::OK) {
     echo "User john successfully removed";
-} elseif ($res == Aerospike::INVALID_USER) {
+} elseif ($res == Aerospike::ERR_INVALID_USER) {
     echo "User john does not exist";
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to drop a user";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_grantroles.md
+++ b/doc/aerospike_grantroles.md
@@ -43,9 +43,9 @@ if (!$client->isConnected()) {
 $res = $client->grantRoles("john", array("read-write", "sys-admin"));
 if ($res == Aerospike::OK) {
     echo "read-write and sys-admin roles successfully granted to user john";
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to grant new roles";
-} elseif ($res == Aerospike::INVALID_ROLE) {
+} elseif ($res == Aerospike::ERR_INVALID_ROLE) {
     echo "Invalid Role being attempted to be assigned to user john";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_queryuser.md
+++ b/doc/aerospike_queryuser.md
@@ -46,14 +46,14 @@ if ($res == Aerospike::OK) {
     $res = $client->queryUser("john", $roles);
     if ($res == Aerospike::OK) {
         var_dump($roles);
-    } elseif ($res == Aerospike::INVALID_USER) {
+    } elseif ($res == Aerospike::ERR_INVALID_USER) {
         echo "Invalid user being queried";
     } else {
         echo "[{$client->errorno()}] ".$client->error();
     }
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to grant new roles";
-} elseif ($res == Aerospike::INVALID_ROLE) {
+} elseif ($res == Aerospike::ERR_INVALID_ROLE) {
     echo "Invalid Role being attempted to be assigned to user john";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_queryusers.md
+++ b/doc/aerospike_queryusers.md
@@ -47,9 +47,9 @@ if ($res == Aerospike::OK) {
     } else {
         echo "[{$client->errorno()}] ".$client->error();
     }
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to create user";
-} elseif ($res == Aerospike::INVALID_ROLE) {
+} elseif ($res == Aerospike::ERR_INVALID_ROLE) {
     echo "Invalid Role being attempted to be assigned to user";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/aerospike_revokeroles.md
+++ b/doc/aerospike_revokeroles.md
@@ -43,9 +43,9 @@ if (!$client->isConnected()) {
 $res = $client->revokeRoles("john", array("user-admin", "sys-admin"));
 if ($res == Aerospike::OK) {
     echo "User john's user-admin and sys-admin roles have been successfully revoked";
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to revoke roles";
-} elseif ($res == Aerospike::INVALID_ROLE) {
+} elseif ($res == Aerospike::ERR_INVALID_ROLE) {
     echo "Invalid Role being attempted to be revoked";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/doc/apiref_security.md
+++ b/doc/apiref_security.md
@@ -92,9 +92,9 @@ if ($res == Aerospike::OK) {
     } else {
         echo "[{$client->errorno()}] ".$client->error();
     }
-} elseif ($res == Aerospike::ROLE_VIOLATION) {
+} elseif ($res == Aerospike::ERR_ROLE_VIOLATION) {
     echo "User does not possess the required role to create user";
-} elseif ($res == Aerospike::INVALID_ROLE) {
+} elseif ($res == Aerospike::ERR_INVALID_ROLE) {
     echo "Invalid Role being attempted to be assigned to user";
 } else {
     echo "[{$client->errorno()}] ".$client->error();

--- a/src/aerospike/aerospike_policy.h
+++ b/src/aerospike/aerospike_policy.h
@@ -114,7 +114,7 @@ AerospikeConstants aerospike_constants[] = {
     { SERIALIZER_USER                       ,   "SERIALIZER_USER"                   },
     { AS_UDF_TYPE_LUA                       ,   "UDF_TYPE_LUA"                      },
     { AS_SCAN_PRIORITY_AUTO 		        ,   "SCAN_PRIORITY_AUTO" 		        },
-    { AS_SCAN_PRIORITY_LOW 		            ,   "SCAN_PRORITY_LOW" 			        },
+    { AS_SCAN_PRIORITY_LOW 		            ,   "SCAN_PRIORITY_LOW" 			    },
     { AS_SCAN_PRIORITY_MEDIUM 		        ,   "SCAN_PRIORITY_MEDIUM" 		        },
     { AS_SCAN_PRIORITY_HIGH 		        ,   "SCAN_PRIORITY_HIGH" 		        },
     { AS_SCAN_STATUS_UNDEF 		            ,   "SCAN_STATUS_UNDEF" 		        },


### PR DESCRIPTION
- Use correct Aerospike constants for errors.
- fix typo from SCAN_PRORITY_LOW to SCAN_PRIORITY_LOW.
- commented method Aerospike::setPassword() because it does not have any documentation and I think it has the same functionality as Aerospike::changePassword()
- fix Aerospike class doc for method register() can handle options