### PR TITLE
Proposal for implementation of PHP object storage in session handler

### DIFF
--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -312,9 +312,9 @@ PS_READ_FUNC(aerospike)
             session_bytes = as_bytes_fromval((as_val *) session_data_p);
             session_bytes_value = as_bytes_get(session_bytes);
             session_bytes_str = (unsigned char *) session_bytes_value;
-
-            *val = estrndup(session_bytes_str, as_bytes_size(session_bytes));
+            
             *vallen = as_bytes_size(session_bytes);
+            *val = estrndup(session_bytes_str, *vallen);
 
             as_val_destroy(session_data_p);
             as_bytes_destroy(session_bytes);

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -315,6 +315,9 @@ PS_READ_FUNC(aerospike)
 
             *val = estrndup(session_raw_p, as_bytes_size(session_bytes_p));
             *vallen = as_bytes_size(session_bytes_p);
+
+            as_val_destroy(session_data_p);
+            as_bytes_destroy(session_bytes_p);
             break;
         default: 
             PHP_EXT_SET_AS_ERR(&error, AEROSPIKE_ERR_CLIENT,

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -369,10 +369,10 @@ PS_WRITE_FUNC(aerospike)
         goto exit;
     }
 
-    if (val == NULL || !strcmp(val, "")) {
+    /*if (val == NULL || !strcmp(val, "")) {
         DEBUG_PHP_EXT_DEBUG("Empty session data");
         goto exit;
-    }
+    }*/
 
     as_key_init_str(&key_put, session_p->ns_p, session_p->set_p, key);
     init_key = 1;


### PR DESCRIPTION
This PR fix PHP object storage in session handler (#100), by using systematically AS_BYTE_PHP data type.

It also adds support for binary session.serialize_handler like igbinary.

I successfully tested with all of these session.serialize_handler : php, php_binary, php_serialize, wddx, igbinary