### PR TITLE
Sessions Handler Backward compatibility

### DIFF
--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -327,6 +327,21 @@ PS_READ_FUNC(aerospike)
 			as_val_destroy(session_data_p);
 			as_bytes_destroy(session_bytes);
 			break;
+        case AS_STRING:
+            if (NULL == (session_bytes_str = as_record_get_str(record_p, AEROSPIKE_SESSION_BIN))) {
+                 PHP_EXT_SET_AS_ERR(&error, AEROSPIKE_ERR_CLIENT,
+                            "Unable to get session bin of the record");
+                 DEBUG_PHP_EXT_DEBUG("Unable to get session bin of the record");
+                 goto exit;
+            }
+
+#if PHP_VERSION_ID < 70000
+            *val = estrndup(session_bytes_str, strlen(session_bytes_str));
+            *vallen = strlen(session_bytes_str);
+#else
+            *val = zend_string_init((const char *)session_bytes_str, strlen(session_bytes_str), 0);
+#endif
+            break;
 		default: 
 			PHP_EXT_SET_AS_ERR(&error, AEROSPIKE_ERR_CLIENT,
 					"Unable to read session bin of the record");

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -329,8 +329,8 @@ PS_READ_FUNC(aerospike)
 			as_bytes_destroy(session_bytes);
 			break;
         case AS_STRING:
-          session_bytes_string = as_string_fromval((as_val *) session_data_p);
-          session_bytes_str = as_string_get(session_bytes_string);
+            session_bytes_string = as_string_fromval((as_val *) session_data_p);
+            session_bytes_str = as_string_get(session_bytes_string);
 #if PHP_VERSION_ID < 70000
             *val = estrndup(session_bytes_str, strlen(session_bytes_str));
             *vallen = strlen(session_bytes_str);

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -283,7 +283,7 @@ PS_READ_FUNC(aerospike)
 	as_bin_value*           session_data_p = NULL;
 	as_bytes*               session_bytes = NULL;
 	uint8_t*                session_bytes_value = NULL;
-	const unsigned char*    session_bytes_str = NULL;
+    const char*             session_bytes_str = NULL;
 
 	DEBUG_PHP_EXT_INFO("In PS_READ_FUNC");
 
@@ -315,7 +315,7 @@ PS_READ_FUNC(aerospike)
 		case AS_BYTES:
 			session_bytes = as_bytes_fromval((as_val *) session_data_p);
 			session_bytes_value = as_bytes_get(session_bytes);
-			session_bytes_str = (unsigned char *) session_bytes_value;
+			session_bytes_str = (char *) session_bytes_value;
 
 			uint32_t size = as_bytes_size(session_bytes);
 #if PHP_VERSION_ID < 70000

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -283,8 +283,8 @@ PS_READ_FUNC(aerospike)
 	as_bin_value*           session_data_p = NULL;
 	as_bytes*               session_bytes = NULL;
 	uint8_t*                session_bytes_value = NULL;
-    const char*             session_bytes_str = NULL;
-    const as_string*        session_bytes_string = NULL;
+	const char*             session_bytes_str = NULL;
+	const as_string*        session_bytes_string = NULL;
 
 	DEBUG_PHP_EXT_INFO("In PS_READ_FUNC");
 
@@ -328,16 +328,16 @@ PS_READ_FUNC(aerospike)
 			as_val_destroy(session_data_p);
 			as_bytes_destroy(session_bytes);
 			break;
-        case AS_STRING:
-            session_bytes_string = as_string_fromval((as_val *) session_data_p);
-            session_bytes_str = as_string_get(session_bytes_string);
+		case AS_STRING:
+			session_bytes_string = as_string_fromval((as_val *) session_data_p);
+			session_bytes_str = as_string_get(session_bytes_string);
 #if PHP_VERSION_ID < 70000
-            *val = estrndup(session_bytes_str, strlen(session_bytes_str));
-            *vallen = strlen(session_bytes_str);
+			*val = estrndup(session_bytes_str, strlen(session_bytes_str));
+			*vallen = strlen(session_bytes_str);
 #else
-            *val = zend_string_init((const char *)session_bytes_str, strlen(session_bytes_str), 0);
+			*val = zend_string_init((const char *)session_bytes_str, strlen(session_bytes_str), 0);
 #endif
-            break;
+			break;
 		default: 
 			PHP_EXT_SET_AS_ERR(&error, AEROSPIKE_ERR_CLIENT,
 					"Unable to read session bin of the record");

--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -284,6 +284,7 @@ PS_READ_FUNC(aerospike)
 	as_bytes*               session_bytes = NULL;
 	uint8_t*                session_bytes_value = NULL;
     const char*             session_bytes_str = NULL;
+    const as_string*        session_bytes_string = NULL;
 
 	DEBUG_PHP_EXT_INFO("In PS_READ_FUNC");
 
@@ -328,13 +329,8 @@ PS_READ_FUNC(aerospike)
 			as_bytes_destroy(session_bytes);
 			break;
         case AS_STRING:
-            if (NULL == (session_bytes_str = as_record_get_str(record_p, AEROSPIKE_SESSION_BIN))) {
-                 PHP_EXT_SET_AS_ERR(&error, AEROSPIKE_ERR_CLIENT,
-                            "Unable to get session bin of the record");
-                 DEBUG_PHP_EXT_DEBUG("Unable to get session bin of the record");
-                 goto exit;
-            }
-
+          session_bytes_string = as_string_fromval((as_val *) session_data_p);
+          session_bytes_str = as_string_get(session_bytes_string);
 #if PHP_VERSION_ID < 70000
             *val = estrndup(session_bytes_str, strlen(session_bytes_str));
             *vallen = strlen(session_bytes_str);


### PR DESCRIPTION
A recent merge of [PR 103](https://github.com/aerospike/aerospike-client-php/pull/103) in July 2016 fixed an important issue concerning Aerospike Session Handler Module that was not able to store null-bytes, resulting in data corruption.

To fix that, serialized values are now stored (since v3.4.9) in binary (Bytes) format vs text (String) format in older versions.

The problem is that it breaks backward compatibility. I mean that older session values stored in String format are not recognized anymore by the session module (expecting Bytes format).

So this proposal fixes this issue allowing Session Handler Module to read String data if such format is detected in Aerospike storage.

Note that this was tested on PHP 5.5, but not on PHP 7.x (though it has been coded).