### PR TITLE
Fix session_destroy warning

### DIFF
--- a/src/aerospike/aerospike_session_handler.c
+++ b/src/aerospike/aerospike_session_handler.c
@@ -472,7 +472,7 @@ exit:
 	if (init_key) {
 		as_key_destroy(&key_remove);
 	}
-	return (error.code == AEROSPIKE_OK) ? SUCCESS : FAILURE;
+	return (error.code == AEROSPIKE_OK || error.code == AEROSPIKE_ERR_RECORD_NOT_FOUND) ? SUCCESS : FAILURE;
 }
 
 /*


### PR DESCRIPTION
Using Aerospike Session Module, when you create a new PHP session with `session_start()` and you destroy it in the same script with `session_destroy()`, session data si never written in Aerospike database.

Assuming this is a normal behaviour (optimization?), here is a fix to prevent a warning in such situation: we just return SUCCESS in the Session Handler Destroy method when row does not exist in database.

Here is a simple script to reproduce the issue:

```
<?php
session_start();
session_destroy();
```

The warning:

```
Warning: session_destroy(): Session object destruction failed in /var/www/test.php on line 3
```
