### PR TITLE
Upgrade conf for AS 3.10 compatibility

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -11,6 +11,7 @@ service {
   transaction-threads-per-queue 8
   proto-fd-max 15000
   work-directory ${home}/var
+  node-id-interface venet0
 }
 
 logging {
@@ -29,13 +30,11 @@ network {
   service {
     address ${service_addr}
     port ${service_port}
-    reuse-address
-    network-interface-name venet0
   }
 
   heartbeat {
     mode multicast
-    address ${multicast_addr}
+    multicast-group ${multicast_addr}
     port ${multicast_port}
 
     interval 150


### PR DESCRIPTION
Travis Build fails due to Aerospike Server 3.10 changes in aerospike.conf:

http://www.aerospike.com/docs/operations/upgrade/network_to_3_10
