### PR TITLE
Fix segfault in Session Handler module

### DIFF
--- a/src/aerospike/aerospike_common.h
+++ b/src/aerospike/aerospike_common.h
@@ -139,9 +139,6 @@
 #define CACHE_EXPIRE_PHP_INI INI_INT("session.cache_expire") ? INI_INT("session.cache_expire") * 60 : 0
 #define SESSION_EXPIRE_PHP_INI INI_INT("session.gc_maxlifetime") ? INI_INT("session.gc_maxlifetime") * 60 : 0
 
-#define AEROSPIKE_SESSION "aerospike"
-#define AEROSPIKE_SESSION_LEN 9
-
 /*
  *******************************************************************************************************
  * MACROS FOR AEROSPIKE GEOJSON CLASS.

--- a/src/aerospike/aerospike_helper.c
+++ b/src/aerospike/aerospike_helper.c
@@ -422,6 +422,11 @@ aerospike_helper_object_from_alias_hash(Aerospike_object* as_object_p,
 		goto exit;
 	}
 
+    if (conf->hosts_size == 0) {
+        status = AEROSPIKE_ERR_PARAM;
+        goto exit;
+    }
+
 	if (persist_flag == false) {
 		ZEND_CREATE_AEROSPIKE_REFERENCE_OBJECT();
 		goto exit;

--- a/src/aerospike/aerospike_helper.c
+++ b/src/aerospike/aerospike_helper.c
@@ -963,21 +963,19 @@ aerospike_helper_check_and_set_config_for_session(as_config *config_p,
 
 	char *save_handler = SAVE_HANDLER_PHP_INI;
 	if (save_handler != NULL) {
-		if (!strncmp(save_handler, AEROSPIKE_SESSION, AEROSPIKE_SESSION_LEN)) {
-			if (!save_path) {
-				save_path = SAVE_PATH_PHP_INI;
-			}
+		if (!save_path) {
+			save_path = SAVE_PATH_PHP_INI;
+		}
 
-			if (save_path) {
-				if (AEROSPIKE_OK != parse_save_path(save_path, session_p,
-					config_p, error_p TSRMLS_CC)) {
-					goto exit;
-				}
-			} else {
-				PHP_EXT_SET_AS_ERR(error_p, AEROSPIKE_ERR_CLIENT, "Could not read SAVE_PATH settings");
-				DEBUG_PHP_EXT_ERROR("Could not read SAVE_PATH settings");
+		if (save_path) {
+			if (AEROSPIKE_OK != parse_save_path(save_path, session_p,
+				config_p, error_p TSRMLS_CC)) {
 				goto exit;
 			}
+		} else {
+			PHP_EXT_SET_AS_ERR(error_p, AEROSPIKE_ERR_CLIENT, "Could not read SAVE_PATH settings");
+			DEBUG_PHP_EXT_ERROR("Could not read SAVE_PATH settings");
+			goto exit;
 		}
 	} else {
 		PHP_EXT_SET_AS_ERR(error_p, AEROSPIKE_ERR_CLIENT, "Could not read SAVE_HANDLER settings");


### PR DESCRIPTION
Using Aerospike Session module is achieved by setting `save_handler` and `save_path` in php.ini like this:

```
session.save_handler="aerospike"
session.save_path="sessions|sess|127.0.0.1:3000"
```

This works well with standard usage:

```
<?php
session_start();
```

But, PHP manage the use this way:

```
<?php
$saveHandler = new \SessionHandler();
session_set_save_handler($saveHandler, false);
session_start();
```

This is often used in PHP frameworks like Symfony.

However, Aerospike extension module segfaults in such situation:

```
php5-fpm[18114]: segfault at 0 ip 00007f37725bff2f sp 00007ffd9d65f598 error 4 in libc-2.13.so[7f37724a3000+184000]
```

This is because PHP changes save_handler value from "aerospike" to "user" when we call session_set_save_handler().

This change occurs here in PHP source: https://github.com/php/php-src/blob/PHP-7.1/ext/session/session.c#L1807

The fix is quite simple: checking `save_handler` value is useless in `aerospike_helper_check_and_set_config_for_session()`. Only `save_path` information is useful.
