### PR TITLE
Fix TTL from session.gc_maxlifetime

### DIFF
--- a/src/aerospike/aerospike_common.h
+++ b/src/aerospike/aerospike_common.h
@@ -137,7 +137,7 @@
 #define SAVE_HANDLER_PHP_INI INI_STR("session.save_handler") ? INI_STR("session.save_handler") : NULL
 #define SAVE_PATH_PHP_INI INI_STR("session.save_path") ? INI_STR("session.save_path") : NULL
 #define CACHE_EXPIRE_PHP_INI INI_INT("session.cache_expire") ? INI_INT("session.cache_expire") * 60 : 0
-#define SESSION_EXPIRE_PHP_INI INI_INT("session.gc_maxlifetime") ? INI_INT("session.gc_maxlifetime") * 60 : 0
+#define SESSION_EXPIRE_PHP_INI INI_INT("session.gc_maxlifetime") ? INI_INT("session.gc_maxlifetime") : 0
 
 /*
  *******************************************************************************************************


### PR DESCRIPTION
PHP variable `session.gc_maxlifetime` is used to define TTL for Aerospike session values.
This variable is already in seconds. So we should not multiply it by 60!

This bug was introduced in v3.4.8 when `session.cache_expire` (which is in minutes) was replaced by `session.gc_maxlifetime` to define TTL.